### PR TITLE
Make environment variables FILENAME and EVENT available

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Install globally `npm install -g chokidar-cmd` or as a project dependency `npm i
       chokidar-cmd -c "npm run less" -t src/    Run less build on changes to either
       -t vendor/                                styles directory
 
+
+     chokidar-cmd -c 'jshint $FILENAME' -t '**/*.js'  Run jshint every time a js file changes on osx/linux.
+     chokidar-cmd -c "jshint %FILENAME%" -t "**/*.js" Run jshint every time a js file changes on windows.
+
 ## npm run usage
 
 Use it directly from your package.json for watching without task runners and without installing globally!

--- a/cmd.js
+++ b/cmd.js
@@ -72,7 +72,9 @@ function runner (command) {
     if (running) return
     running = true
     verboseLog('Executing command: ' + command)
-    execAsync(command, function (err) {
+
+    var env = {FILENAME: path, EVENT: event};
+    execAsync(command, env, function (err) {
       if (err) logError(err)
       else verboseLog('Command "' + command + '" completed successfully')
 
@@ -93,8 +95,8 @@ function verboseLog (msg) {
   if (argv.verbose) log(msg)
 }
 
-function execAsync (cmd, callback) {
-  var c = child.exec(cmd, { env: process.env }, function (err) {
+function execAsync (cmd, env, callback) {
+    var c = child.exec(cmd, { env: Object.assign(process.env, env) }, function (err) {
     callback(err || null)
   })
 

--- a/cmd.js
+++ b/cmd.js
@@ -98,7 +98,7 @@ function verboseLog (msg) {
 }
 
 function execAsync (cmd, env, callback) {
-    var c = child.exec(cmd, {env: env}, function (err) {
+  var c = child.exec(cmd, {env: env}, function (err) {
     callback(err || null)
   })
 

--- a/cmd.js
+++ b/cmd.js
@@ -3,6 +3,7 @@
 
 var chokidar = require('chokidar')
 var child = require('child_process')
+const objectAssign = require('object-assign');
 var argv = require('yargs')
   .usage('Usage: chokidar-cmd -c "command" -t file-or-dir-or-glob')
   .command('chokidar-cmd', 'Watch directory or file for changes and run given command')
@@ -73,9 +74,7 @@ function runner (command) {
     running = true
     verboseLog('Executing command: ' + command)
 
-    var env = process.env
-    env.FILENAME = path
-    env.EVENT = event
+    var env = objectAssign({}, process.env, {FILENAME: path, EVENT: event})
     execAsync(command, env, function (err) {
       if (err) logError(err)
       else verboseLog('Command "' + command + '" completed successfully')

--- a/cmd.js
+++ b/cmd.js
@@ -3,7 +3,7 @@
 
 var chokidar = require('chokidar')
 var child = require('child_process')
-const objectAssign = require('object-assign');
+var objectAssign = require('object-assign')
 var argv = require('yargs')
   .usage('Usage: chokidar-cmd -c "command" -t file-or-dir-or-glob')
   .command('chokidar-cmd', 'Watch directory or file for changes and run given command')

--- a/cmd.js
+++ b/cmd.js
@@ -73,7 +73,9 @@ function runner (command) {
     running = true
     verboseLog('Executing command: ' + command)
 
-    var env = {FILENAME: path, EVENT: event};
+    var env = process.env
+    env.FILENAME = path
+    env.EVENT = event
     execAsync(command, env, function (err) {
       if (err) logError(err)
       else verboseLog('Command "' + command + '" completed successfully')
@@ -96,7 +98,7 @@ function verboseLog (msg) {
 }
 
 function execAsync (cmd, env, callback) {
-    var c = child.exec(cmd, { env: Object.assign(process.env, env) }, function (err) {
+    var c = child.exec(cmd, {env: env}, function (err) {
     callback(err || null)
   })
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "mocha": "^3.0.2",
-    "standard": "^8.0.0",
+    "standard": "^8.6.0",
     "touch": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "chokidar": "^1.0.0",
-    "yargs": "^5.0.0"
+    "yargs": "^5.0.0",
+    "object-assign": "^4.1.1"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
Make the environment variables FILENAME and EVENT available for the supplied command. Makes it possible to only run jshint on the file that has changed:

```
  chokidar-cmd -c 'jshint $FILENAME' -t '**/*.js'
```

I got the idea for this feature when I wrote my similar command line utility in ruby https://github.com/thomasfl/filewatcher 